### PR TITLE
Bugfix/corrir nome classe

### DIFF
--- a/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/component/TaskRepositoryCustomImpl.java
+++ b/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/component/TaskRepositoryCustomImpl.java
@@ -1,0 +1,47 @@
+package com.jorge.projeto.tarefas.tarefas_java_jwt.component;
+
+import com.jorge.projeto.tarefas.tarefas_java_jwt.interfaces.TaskRepositoryCustom;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.model.task.TaskStatus;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.model.task.Tasks;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Repository
+public class TaskRepositoryCustomImpl implements TaskRepositoryCustom {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Override
+    public List<Tasks> findByFilters(TaskStatus status, LocalDate startDate, LocalDate endDate, Long responsibleId) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Tasks> query = cb.createQuery(Tasks.class);
+        Root<Tasks> task = query.from(Tasks.class);
+
+        List<Predicate> predicates = new ArrayList<>();
+
+        if (status != null) {
+            predicates.add(cb.equal(task.get("status"), status));
+        }
+        if (startDate != null) {
+            predicates.add(cb.greaterThanOrEqualTo(task.get("createdAt"), startDate));
+        }
+        if (endDate != null) {
+            predicates.add(cb.lessThanOrEqualTo(task.get("createdAt"), endDate));
+        }
+        if (responsibleId != null) {
+            predicates.add(cb.equal(task.get("responsible").get("id"), responsibleId));
+        }
+
+        query.where(cb.and(predicates.toArray(new Predicate[0])));
+        return entityManager.createQuery(query).getResultList();
+    }
+}

--- a/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/controllers/AdminController.java
+++ b/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/controllers/AdminController.java
@@ -1,10 +1,10 @@
 package com.jorge.projeto.tarefas.tarefas_java_jwt.controllers;
 
-mport com.jorge.projeto.tarefas.tarefas_java_jwt.dto.RegisterRequestDTO;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.dto.RegisterRequestDTO;
 import com.jorge.projeto.tarefas.tarefas_java_jwt.dto.UserDTO;
 import com.jorge.projeto.tarefas.tarefas_java_jwt.model.role.Role;
 import com.jorge.projeto.tarefas.tarefas_java_jwt.model.user.User;
-import com.jorge.projeto.tarefas.tarefas_java_jwt.repository.UserRepository;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.interfaces.repository.UserRepository;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 

--- a/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/controllers/AdminController.java
+++ b/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/controllers/AdminController.java
@@ -1,0 +1,56 @@
+package com.jorge.projeto.tarefas.tarefas_java_jwt.controllers;
+
+mport com.jorge.projeto.tarefas.tarefas_java_jwt.dto.RegisterRequestDTO;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.dto.UserDTO;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.model.role.Role;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.model.user.User;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.repository.UserRepository;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/admin")
+@PreAuthorize("hasAuthority('ADMIN')")
+public class AdminController {
+    private final UserRepository repository;
+    private final PasswordEncoder passwordEncoder;
+
+    public AdminController(UserRepository repository, PasswordEncoder passwordEncoder) {
+        this.repository = repository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<?> registerAdmin(@RequestBody RegisterRequestDTO body) {
+        Optional<User> user = repository.findByEmail(body.email());
+        if(user.isEmpty()) {
+            User admin = new User();
+            admin.setEmail(body.email());
+            admin.setPassword(passwordEncoder.encode(body.password()));
+            admin.setName(body.name());
+            admin.setRole(Role.ADMIN);
+            admin.setCreatedAt(LocalDateTime.now());
+            repository.save(admin);
+            return ResponseEntity.ok("Usuário do tipo ADMIN cadastrado com sucesso!");
+        }
+        return ResponseEntity.badRequest().body("Email já existe.");
+    }
+
+    @GetMapping("/users")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<List<UserDTO>> getAllUsers() {
+        List<UserDTO> users = repository.findAll().stream()
+                .map(UserDTO::new)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(users);
+    }
+}

--- a/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/controllers/AuthController.java
+++ b/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/controllers/AuthController.java
@@ -1,11 +1,11 @@
 package com.jorge.projeto.tarefas.tarefas_java_jwt.controllers;
 
-mport com.jorge.projeto.tarefas.tarefas_java_jwt.dto.LoginRequestDTO;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.dto.LoginRequestDTO;
 import com.jorge.projeto.tarefas.tarefas_java_jwt.dto.RegisterRequestDTO;
 import com.jorge.projeto.tarefas.tarefas_java_jwt.dto.ResponseDTO;
 import com.jorge.projeto.tarefas.tarefas_java_jwt.model.role.Role;
 import com.jorge.projeto.tarefas.tarefas_java_jwt.model.user.User;
-import com.jorge.projeto.tarefas.tarefas_java_jwt.repository.UserRepository;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.interfaces.repository.UserRepository;
 import com.jorge.projeto.tarefas.tarefas_java_jwt.infra.security.TokenService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/controllers/AuthController.java
+++ b/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/controllers/AuthController.java
@@ -1,0 +1,64 @@
+package com.jorge.projeto.tarefas.tarefas_java_jwt.controllers;
+
+mport com.jorge.projeto.tarefas.tarefas_java_jwt.dto.LoginRequestDTO;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.dto.RegisterRequestDTO;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.dto.ResponseDTO;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.model.role.Role;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.model.user.User;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.repository.UserRepository;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.infra.security.TokenService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+//@CrossOrigin(origins = "http://localhost:5173", allowCredentials = "true")
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+    private final UserRepository repository;
+    private final PasswordEncoder passwordEncoder;
+    private final TokenService tokenService;
+
+    @PostMapping("/login")
+    public ResponseEntity login(@RequestBody LoginRequestDTO body ) {
+        User user = this.repository.findByEmail(body.email()).orElseThrow(() -> new RuntimeException("User not Found"));
+        if(passwordEncoder.matches(body.password(), user.getPassword())){
+            String token = this.tokenService.generateToken(user);
+            return ResponseEntity.ok(new ResponseDTO(user.getId(),
+                    user.getName(),
+                    user.getEmail(),
+                    user.getRole(),
+                    token));
+        }
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping("/register")
+    public ResponseEntity<?> register(@RequestBody @Valid RegisterRequestDTO body ) {
+        Optional<User> user = this.repository.findByEmail(body.email());
+        if(user.isEmpty()){
+            User newUser = new User();
+            newUser.setPassword(passwordEncoder.encode(body.password()));
+            newUser.setEmail(body.email());
+            newUser.setName(body.name());
+            newUser.setRole(Role.USER);
+            newUser.setCreatedAt(LocalDateTime.now());
+            this.repository.save(newUser);
+            String token = this.tokenService.generateToken(newUser);
+            return ResponseEntity.ok(new ResponseDTO(newUser.getId(), newUser.getName(), newUser.getEmail(), newUser.getRole(), token));
+        }
+        //return ResponseEntity.badRequest().build();
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body("E-mail já existe");
+    }
+}

--- a/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/controllers/TaskController.java
+++ b/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/controllers/TaskController.java
@@ -1,0 +1,173 @@
+package com.jorge.projeto.tarefas.tarefas_java_jwt.controllers;
+
+import com.jorge.projeto.tarefas.tarefas_java_jwt.dto.ResponsibleUpdateDTO;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.dto.TaskRequestDTO;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.dto.TaskResponseDTO;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.infra.UserDetailsImpl;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.model.task.TaskStatus;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.repository.TaskRepository;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.service.TaskService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.model.task.Tasks;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/tasks")
+@RequiredArgsConstructor
+public class TaskController {
+
+    @Autowired
+    private TaskService taskService;
+
+    private final TaskRepository taskRepo;
+
+    @PreAuthorize("hasRole('USER')")
+    @GetMapping("/user")
+    public List<Tasks> getTasksForUser(Authentication auth) {
+        UserDetailsImpl userDetails = (UserDetailsImpl) auth.getPrincipal();
+        Long userId = userDetails.getId();
+        return taskRepo.findByFilters(null, null, null, userId);
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/admin")
+    public List<Tasks> getAllTasks() {
+        return taskRepo.findAll();
+    }
+
+
+    @GetMapping("/admin/{id}")
+    public ResponseEntity<TaskResponseDTO> getTaskById(@PathVariable Long id) {
+        Optional<Tasks> optionalTask = taskRepo.findById(id);
+        if (optionalTask.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        Tasks task = optionalTask.get();
+        TaskResponseDTO dto = taskService.convertToResponseDTO(task);
+        return ResponseEntity.ok(dto);
+    }
+
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteTask(@PathVariable Long id) {
+        Optional<ResponseEntity<Void>> response = taskRepo.findById(id)
+                .map(task -> {
+                    taskRepo.delete(task);
+                    return ResponseEntity.noContent().build();
+                });
+        return response.orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping("/create")
+    @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
+    public ResponseEntity<TaskResponseDTO> createTask(@RequestBody @Valid TaskRequestDTO dto, Authentication authentication) {
+        TaskResponseDTO created = taskService.createTask(dto, authentication);
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+
+    @PutMapping("/user/{id}")
+    @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
+    public ResponseEntity<?> updateTaskByUser(
+            @PathVariable Long id,
+            @RequestBody TaskRequestDTO dto,
+            Authentication auth) {
+
+        if (auth == null || !(auth.getPrincipal() instanceof Jwt)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Usuário não autenticado corretamente.");
+        }
+
+        Jwt jwt = (Jwt) auth.getPrincipal();
+
+        String userIdStr = jwt.getClaimAsString("user_id");
+        if (userIdStr == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("ID do usuário não encontrado no token.");
+        }
+
+        Long userId;
+        try {
+            userId = Long.parseLong(userIdStr);
+        } catch (NumberFormatException e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("ID do usuário inválido no token.");
+        }
+
+        Optional<Tasks> optionalTask = taskRepo.findById(id);
+        if (optionalTask.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        Tasks task = optionalTask.get();
+
+        // Verifica se o usuário autenticado é responsável pela tarefa
+        if (task.getResponsible() == null || !task.getResponsible().getId().equals(userId)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body("Você não tem permissão para editar esta tarefa.");
+        }
+
+        // Atualiza os campos permitidos
+        task.setStatus(dto.getStatus());
+
+        taskRepo.save(task);
+        return ResponseEntity.ok("Tarefa atualizada com sucesso.");
+    }
+
+
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @PutMapping("/{id}/responsible")
+    public ResponseEntity<?> updateResponsible(
+            @PathVariable Long id,
+            @RequestBody ResponsibleUpdateDTO dto,
+            @AuthenticationPrincipal Jwt jwt
+    ) {
+        String role = jwt.getClaimAsString("role");
+
+        if (!"ADMIN".equals(role)) {
+            throw new AccessDeniedException("Apenas administradores podem trocar o responsável de uma tarefa.");
+        }
+
+        taskService.updateResponsible(id, dto.getResponsibleId());
+        return ResponseEntity.ok(Map.of("message", "Responsável atualizado com sucesso."));
+    }
+
+
+
+
+    @GetMapping("/filter")
+    @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
+    public ResponseEntity<List<TaskResponseDTO>> filterTasks(
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+            @RequestParam(required = false) Long userId,
+            Authentication authentication
+    ) {
+        TaskStatus taskStatus = null;
+        if (status != null && !status.isBlank()) {
+            try {
+                taskStatus = TaskStatus.valueOf(status.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                return ResponseEntity.badRequest().build(); // status inválido
+            }
+        }
+        List<TaskResponseDTO> filteredTasks = taskService.filterTasks(taskStatus, startDate, endDate, userId, authentication);
+        return ResponseEntity.ok(filteredTasks);
+    }
+
+
+
+}

--- a/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/controllers/TaskController.java
+++ b/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/controllers/TaskController.java
@@ -5,7 +5,7 @@ import com.jorge.projeto.tarefas.tarefas_java_jwt.dto.TaskRequestDTO;
 import com.jorge.projeto.tarefas.tarefas_java_jwt.dto.TaskResponseDTO;
 import com.jorge.projeto.tarefas.tarefas_java_jwt.infra.UserDetailsImpl;
 import com.jorge.projeto.tarefas.tarefas_java_jwt.model.task.TaskStatus;
-import com.jorge.projeto.tarefas.tarefas_java_jwt.repository.TaskRepository;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.interfaces.repository.TaskRepository;
 import com.jorge.projeto.tarefas.tarefas_java_jwt.service.TaskService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/dto/AuthRequestDTO.java
+++ b/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/dto/AuthRequestDTO.java
@@ -1,0 +1,4 @@
+package com.jorge.projeto.tarefas.tarefas_java_jwt.dto;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.model.role.Role;
+
+public record AuthRequestDTO(String email, String password, Role role) {}

--- a/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/dto/AuthResponseDTO.java
+++ b/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/dto/AuthResponseDTO.java
@@ -1,0 +1,3 @@
+package com.jorge.projeto.tarefas.tarefas_java_jwt.dto;
+
+public record AuthResponseDTO(String token) {}

--- a/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/dto/LoginRequestDTO.java
+++ b/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/dto/LoginRequestDTO.java
@@ -1,0 +1,3 @@
+package com.jorge.projeto.tarefas.tarefas_java_jwt.dto;
+
+public record LoginRequestDTO (String email,  String password){ }

--- a/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/dto/RegisterRequestDTO.java
+++ b/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/dto/RegisterRequestDTO.java
@@ -1,0 +1,15 @@
+package com.jorge.projeto.tarefas.tarefas_java_jwt.dto;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+import com.jorge.projeto.tarefas.tarefas_java_jwt.model.role.Role;
+
+public record RegisterRequestDTO (
+        @NotBlank
+        String name,
+        @Email
+        String email,
+        @NotBlank
+        String password,
+        Role role
+) { }

--- a/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/dto/ResponseDTO.java
+++ b/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/dto/ResponseDTO.java
@@ -1,0 +1,6 @@
+package com.jorge.projeto.tarefas.tarefas_java_jwt.dto;
+
+import com.jorge.projeto.tarefas.tarefas_java_jwt.model.role.Role;
+
+public record ResponseDTO (Long id, String name, String email, Role role, String token){
+}

--- a/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/dto/ResponsibleDTO.java
+++ b/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/dto/ResponsibleDTO.java
@@ -1,0 +1,14 @@
+package com.jorge.projeto.tarefas.tarefas_java_jwt.dto;
+
+import com.jorge.projeto.tarefas.tarefas_java_jwt.model.role.Role;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ResponsibleDTO {
+    private Long id;
+    private String name;
+    private Role role;
+
+}

--- a/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/dto/ResponsibleUpdateDTO.java
+++ b/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/dto/ResponsibleUpdateDTO.java
@@ -1,0 +1,10 @@
+package com.jorge.projeto.tarefas.tarefas_java_jwt.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ResponsibleUpdateDTO {
+    private Long responsibleId;
+}

--- a/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/dto/TaskRequestDTO.java
+++ b/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/dto/TaskRequestDTO.java
@@ -1,0 +1,26 @@
+package com.jorge.projeto.tarefas.tarefas_java_jwt.dto;
+
+import java.time.LocalDate;
+
+import com.jorge.projeto.tarefas.tarefas_java_jwt.model.task.TaskStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TaskRequestDTO {
+    @NotBlank
+    private String title;
+
+    @NotBlank
+    private String description;
+
+    @NotNull
+    private LocalDate dueDate;
+
+    private TaskStatus status;
+
+    private Long responsibleId;
+}

--- a/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/dto/TaskResponseDTO.java
+++ b/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/dto/TaskResponseDTO.java
@@ -1,0 +1,20 @@
+package com.jorge.projeto.tarefas.tarefas_java_jwt.dto;
+
+import com.jorge.projeto.tarefas.tarefas_java_jwt.model.role.Role;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.model.task.TaskStatus;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TaskResponseDTO {
+    private Long id;
+    private String title;
+    private String description;
+    private String createdAt;
+    private String dueDate;
+    private ResponsibleDTO responsible;
+    private TaskStatus status;
+    private Role role;
+
+}

--- a/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/dto/UserDTO.java
+++ b/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/dto/UserDTO.java
@@ -1,0 +1,18 @@
+package com.jorge.projeto.tarefas.tarefas_java_jwt.dto;
+
+import com.jorge.projeto.tarefas.tarefas_java_jwt.model.user.User;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserDTO {
+    private Long id;
+    private  String name;
+
+    public UserDTO(User user) {
+        this.id = user.getId();
+        this.name = user.getName();
+    }
+
+}

--- a/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/dto/UserResponseDTO.java
+++ b/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/dto/UserResponseDTO.java
@@ -1,0 +1,11 @@
+package com.jorge.projeto.tarefas.tarefas_java_jwt.dto;
+
+import com.jorge.projeto.tarefas.tarefas_java_jwt.model.user.User;
+
+
+public record UserResponseDTO(Long id, String name, String email, String role) {
+    public UserResponseDTO(User user) {
+        this(user.getId(), user.getName(), user.getEmail(), user.getRole().name());
+
+    }
+}

--- a/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/exception/TokenCreationException.java
+++ b/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/exception/TokenCreationException.java
@@ -1,0 +1,7 @@
+package com.jorge.projeto.tarefas.tarefas_java_jwt.exception;
+
+public class TokenCreationException extends RuntimeException {
+    public TokenCreationException(String message) {
+        super(message);
+    }
+}

--- a/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/infra/UserDetailsImpl.java
+++ b/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/infra/UserDetailsImpl.java
@@ -1,0 +1,52 @@
+package com.jorge.projeto.tarefas.tarefas_java_jwt.infra;
+
+import com.jorge.projeto.tarefas.tarefas_java_jwt.model.role.Role;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.model.user.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+
+@AllArgsConstructor
+@Getter
+public class UserDetailsImpl implements UserDetails {
+    private final Long id;
+    private final String email;
+    private final String password;
+    private final Role role;
+
+    public Role getRole() {
+        return role;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        //return Collections.emptyList();
+        return List.of(new SimpleGrantedAuthority("ROLE_" + role.name()));
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override public boolean isAccountNonExpired() { return true; }
+    @Override public boolean isAccountNonLocked() { return true; }
+    @Override public boolean isCredentialsNonExpired() { return true; }
+    @Override public boolean isEnabled() { return true; }
+
+    // Factory method para criar a partir do User
+    public static UserDetailsImpl build(User user) {
+        return new UserDetailsImpl(user.getId(), user.getEmail(), user.getPassword(), user.getRole());
+    }
+}

--- a/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/infra/security/CustomUserDetailsService.java
+++ b/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/infra/security/CustomUserDetailsService.java
@@ -1,4 +1,4 @@
-package com.jorge.projeto.tarefas.tarefas_java_jwt.security;
+package com.jorge.projeto.tarefas.tarefas_java_jwt.infra.security;
 
 import com.jorge.projeto.tarefas.tarefas_java_jwt.infra.UserDetailsImpl;
 import com.jorge.projeto.tarefas.tarefas_java_jwt.model.user.User;

--- a/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/infra/security/CustomUserDetailsService.java
+++ b/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/infra/security/CustomUserDetailsService.java
@@ -2,7 +2,7 @@ package com.jorge.projeto.tarefas.tarefas_java_jwt.infra.security;
 
 import com.jorge.projeto.tarefas.tarefas_java_jwt.infra.UserDetailsImpl;
 import com.jorge.projeto.tarefas.tarefas_java_jwt.model.user.User;
-import com.jorge.projeto.tarefas.tarefas_java_jwt.repository.UserRepository;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.interfaces.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;

--- a/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/infra/security/SecurityConfig.java
+++ b/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/infra/security/SecurityConfig.java
@@ -1,4 +1,4 @@
-package com.jorge.projeto.tarefas.tarefas_java_jwt.security;
+package com.jorge.projeto.tarefas.tarefas_java_jwt.infra.security;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;

--- a/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/infra/security/SecurityFilter.java
+++ b/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/infra/security/SecurityFilter.java
@@ -1,4 +1,4 @@
-package com.jorge.projeto.tarefas.tarefas_java_jwt.security;
+package com.jorge.projeto.tarefas.tarefas_java_jwt.infra.security;
 
 import com.jorge.projeto.tarefas.tarefas_java_jwt.infra.UserDetailsImpl;
 import com.jorge.projeto.tarefas.tarefas_java_jwt.model.user.User;

--- a/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/infra/security/TokenService.java
+++ b/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/infra/security/TokenService.java
@@ -1,4 +1,4 @@
-package com.jorge.projeto.tarefas.tarefas_java_jwt.security;
+package com.jorge.projeto.tarefas.tarefas_java_jwt.infra.security;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;

--- a/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/interfaces/TaskRepositoryCustom.java
+++ b/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/interfaces/TaskRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.jorge.projeto.tarefas.tarefas_java_jwt.interfaces;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.model.task.TaskStatus;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.model.task.Tasks;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface TaskRepositoryCustom {
+    List<Tasks> findByFilters(TaskStatus status, LocalDate startDate, LocalDate endDate, Long responsibleId);
+}

--- a/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/interfaces/repository/TaskRepository.java
+++ b/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/interfaces/repository/TaskRepository.java
@@ -1,0 +1,12 @@
+package com.jorge.projeto.tarefas.tarefas_java_jwt.interfaces.repository;
+
+import com.jorge.projeto.tarefas.tarefas_java_jwt.interfaces.TaskRepositoryCustom;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.model.task.Tasks;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TaskRepository extends JpaRepository<Tasks, Long>, TaskRepositoryCustom {
+    List<Tasks> findByResponsibleId(Long userId);
+}

--- a/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/interfaces/repository/UserRepository.java
+++ b/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/interfaces/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.jorge.projeto.tarefas.tarefas_java_jwt.interfaces.repository;
+
+import com.jorge.projeto.tarefas.tarefas_java_jwt.model.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+}

--- a/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/model/task/TaskStatus.java
+++ b/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/model/task/TaskStatus.java
@@ -1,0 +1,7 @@
+package com.jorge.projeto.tarefas.tarefas_java_jwt.model.task;
+
+public enum TaskStatus {
+    TODO,
+    IN_PROGRESS,
+    DONE
+}

--- a/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/model/task/Tasks.java
+++ b/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/model/task/Tasks.java
@@ -1,0 +1,48 @@
+package com.jorge.projeto.tarefas.tarefas_java_jwt.model.task;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.model.user.User;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Tasks {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status")
+    private TaskStatus status;
+
+    @Column(name = "due_date")
+    private LocalDate dueDate;
+
+    //@JsonIgnore
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "responsible_id")
+    @JsonIgnoreProperties({"email", "password", "roles"})
+    private User responsible;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+}
+

--- a/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/model/token/RefreshToken.java
+++ b/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/model/token/RefreshToken.java
@@ -1,0 +1,28 @@
+package com.jorge.projeto.tarefas.tarefas_java_jwt.model.token;
+
+import com.jorge.projeto.tarefas.tarefas_java_jwt.model.user.User;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RefreshToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String token;
+    private LocalDateTime expiryDate;
+
+    @OneToOne
+    @JoinColumn(name = "user_id", referencedColumnName = "id")
+    private User user;
+}

--- a/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/service/AuthService.java
+++ b/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/service/AuthService.java
@@ -1,0 +1,58 @@
+package com.jorge.projeto.tarefas.tarefas_java_jwt.service;
+
+import com.jorge.projeto.tarefas.tarefas_java_jwt.dto.AuthRequestDTO;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.dto.AuthResponseDTO;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.dto.RegisterRequestDTO;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.infra.security.TokenService;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.model.role.Role;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.interfaces.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.model.user.User;
+
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthService {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private AuthenticationManager authenticationManager;
+
+    @Autowired
+    private TokenService tokenService;
+
+    public AuthResponseDTO login(AuthRequestDTO dto) {
+        var auth = new UsernamePasswordAuthenticationToken(dto.email(), dto.password());
+        authenticationManager.authenticate(auth); // lança exceção se inválido
+
+        User user = userRepository.findByEmail(dto.email())
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+
+        String token = tokenService.generateToken(user);
+        return new AuthResponseDTO(token);
+    }
+
+    public AuthResponseDTO register(RegisterRequestDTO dto) {
+        if (userRepository.findByEmail(dto.email()).isPresent()) {
+            throw new IllegalArgumentException("Email já cadastrado");
+        }
+
+        User user = new User();
+        user.setEmail(dto.email());
+        user.setPassword(passwordEncoder.encode(dto.password()));
+        user.setRole(dto.role() != null ? dto.role() : Role.USER);
+
+        userRepository.save(user);
+        String token = tokenService.generateToken(user);
+        return new AuthResponseDTO(token);
+    }
+}

--- a/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/service/TaskService.java
+++ b/tarefas-java-jwt/src/main/java/com/jorge/projeto/tarefas/tarefas_java_jwt/service/TaskService.java
@@ -1,0 +1,146 @@
+package com.jorge.projeto.tarefas.tarefas_java_jwt.service;
+
+
+import com.jorge.projeto.tarefas.tarefas_java_jwt.dto.ResponsibleDTO;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.dto.TaskRequestDTO;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.dto.TaskResponseDTO;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.model.role.Role;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.model.task.TaskStatus;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.model.task.Tasks;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.model.user.User;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.interfaces.repository.UserRepository;
+import com.jorge.projeto.tarefas.tarefas_java_jwt.interfaces.repository.TaskRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+public class TaskService {
+
+    @Autowired
+    private TaskRepository taskRepo;
+
+    @Autowired
+    private UserRepository userRepo;
+
+
+    public TaskResponseDTO createTask(TaskRequestDTO dto, Authentication auth) {
+        Jwt jwt = (Jwt) auth.getPrincipal();
+
+        Long jwtUserId = Long.valueOf(jwt.getClaimAsString("id"));
+        String roleStr = jwt.getClaimAsString("role");
+
+        if (roleStr == null) {
+            throw new IllegalArgumentException("Claim 'role' não encontrado no token JWT.");
+        }
+
+        Role role = Role.valueOf(roleStr);
+
+        Tasks task = new Tasks();
+        task.setTitle(dto.getTitle());
+        task.setDescription(dto.getDescription());
+        task.setDueDate(dto.getDueDate());
+        task.setCreatedAt(LocalDateTime.now());
+        task.setStatus(dto.getStatus());
+
+        if (role == Role.USER) {
+            User currentUser = userRepo.findById(jwtUserId)
+                    .orElseThrow(() -> new UsernameNotFoundException("Usuário não encontrado"));
+            task.setResponsible(currentUser);
+        } else if (role == Role.ADMIN) {
+            if (dto.getResponsibleId() != null) {
+                User responsible = userRepo.findById(dto.getResponsibleId())
+                        .orElseThrow(() -> new UsernameNotFoundException("Responsável não encontrado"));
+                task.setResponsible(responsible);
+            } else {
+                User currentUser = userRepo.findById(jwtUserId)
+                        .orElseThrow(() -> new UsernameNotFoundException("Usuário não encontrado"));
+                task.setResponsible(currentUser);
+            }
+        } else {
+            throw new AccessDeniedException("Role não autorizada para criar tarefas");
+        }
+
+        Tasks saved = taskRepo.save(task);
+        return toDTO(saved);
+    }
+
+
+
+    public List<TaskResponseDTO> filterTasks(TaskStatus status, LocalDate start, LocalDate end, Long userId, Authentication auth) {
+        Jwt jwt = (Jwt) auth.getPrincipal();
+
+        Long jwtUserId = Long.valueOf(jwt.getClaimAsString("id"));
+
+        String role = jwt.getClaimAsString("role");
+
+        if (Role.USER.name().equals(role)) {
+            userId = jwtUserId;
+        }
+
+        List<Tasks> tasks = taskRepo.findByFilters(status, start, end, userId);
+
+        return tasks.stream().map(this::toDTO).toList();
+    }
+
+
+    private TaskResponseDTO toDTO(Tasks task) {
+        TaskResponseDTO dto = new TaskResponseDTO();
+        dto.setId(task.getId());
+        dto.setTitle(task.getTitle());
+        dto.setDescription(task.getDescription());
+        dto.setRole(task.getResponsible().getRole());
+
+        dto.setDueDate(task.getDueDate().toString());
+        if (task.getResponsible() != null) {
+            ResponsibleDTO res = new ResponsibleDTO();
+            res.setId(task.getResponsible().getId());
+            res.setName(task.getResponsible().getName());
+            dto.setResponsible(res);
+        }
+        return dto;
+    }
+
+    //Trocar de responsável na tarefa
+    public void updateResponsible(Long taskId, Long newResponsibleId) {
+        Tasks task = taskRepo.findById(taskId)
+                .orElseThrow(() -> new EntityNotFoundException("Tarefa não encontrada"));
+
+        User responsible = userRepo.findById(newResponsibleId)
+                .orElseThrow(() -> new EntityNotFoundException("Usuário não encontrado"));
+
+        task.setResponsible(responsible);
+        taskRepo.save(task);
+    }
+
+
+
+
+    public TaskResponseDTO convertToResponseDTO(Tasks task) {
+        TaskResponseDTO dto = new TaskResponseDTO();
+        dto.setId(task.getId());
+        dto.setTitle(task.getTitle());
+        dto.setDescription(task.getDescription());
+        dto.setCreatedAt(task.getCreatedAt() != null ? task.getCreatedAt().toString() : null);
+        dto.setDueDate(task.getDueDate() != null ? task.getDueDate().toString() : null);
+        if (task.getResponsible() != null) {
+            ResponsibleDTO respDto = new ResponsibleDTO();
+            respDto.setId(task.getResponsible().getId());
+            respDto.setName(task.getResponsible().getName());
+            dto.setResponsible(respDto);
+        }
+        dto.setStatus(task.getStatus());
+        return dto;
+    }
+
+
+}
+


### PR DESCRIPTION
- Ajustado a nomeclartura da classe que estava dando erro ao executar;
- Classe para validar os dados da Task do usuário ocorria erro ao puxar o id, corrigido a nomeclatura para o JPA puxar corretamente.